### PR TITLE
feat(api,runs): lifecycle watchers (running/done/error/canceled) via bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ Fetch run metadata:
 curl -s http://localhost:3000/runs/<uuid>
 ```
 
+### Run Lifecycle
+
+Runs automatically transition through statuses via bus messages:
+
+- **queued** → **dispatched** → **running** (on first log) → **done**|**error**|**canceled**
+
+The API subscribes to `runs.<id>.logs` and `runs.<id>.status` topics when a run is created. Agents can emit status updates:
+
+```json
+{"state": "done", "detail": {"result": "success"}}
+{"state": "error", "detail": "Something went wrong"}
+{"state": "canceled", "detail": "User requested cancellation"}
+```
+
 ## Code Style
 
 - Language: TypeScript (Node ESM)

--- a/packages/api/src/bus/topics.ts
+++ b/packages/api/src/bus/topics.ts
@@ -1,6 +1,7 @@
 export const topics = {
   runLogs: (runId: string) => `runs.${runId}.logs`,
   runPatch: (runId: string) => `runs.${runId}.patch`,
+  runStatus: (runId: string) => `runs.${runId}.status`,
   agentWork: (agentId: string) => `agents.${agentId}.work`,
   runControl: (runId: string) => `runs.${runId}.control`,
   agentHeartbeat: (agentId: string) => `agents.${agentId}.heartbeat`,

--- a/packages/api/src/runs/repo.memory.ts
+++ b/packages/api/src/runs/repo.memory.ts
@@ -1,4 +1,4 @@
-export type RunStatus = 'queued' | 'dispatched' | 'done' | 'error';
+export type RunStatus = 'queued' | 'dispatched' | 'running' | 'done' | 'error' | 'canceled';
 
 export type RunRecord = {
   id: string;

--- a/packages/api/src/runs/routes.ts
+++ b/packages/api/src/runs/routes.ts
@@ -5,6 +5,8 @@ import { topics } from '../bus/topics.js';
 import type { RunsRepo } from './repo.memory.js';
 
 export function registerRunRoutes(app: FastifyInstance, deps: { bus: Bus; repo: RunsRepo }) {
+  // TODO: Consider exposing last error/reason on GET /runs/:id when state=error|canceled
+  // This would require storing the detail from status messages in the repo
   app.post(
     '/runs',
     {

--- a/packages/api/test/e2e.runs.sse.test.ts
+++ b/packages/api/test/e2e.runs.sse.test.ts
@@ -125,7 +125,7 @@ describe('E2E: run dispatch + SSE logs', () => {
       expect(getRes.status).toBe(200);
       const rec = await getRes.json();
       expect(rec.id).toBe(id);
-      expect(rec.status).toBe('dispatched');
+      expect(rec.status).toBe('running');
 
       await unsubWork();
     } finally {

--- a/packages/api/test/runs.status.test.ts
+++ b/packages/api/test/runs.status.test.ts
@@ -57,4 +57,88 @@ describe('runs lifecycle via bus watchers', () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(repo.get(id2)?.status).toBe('canceled');
   });
+
+  it('status arrives before first log - sets final state directly and cleans both watchers', async () => {
+    const app = Fastify();
+    const bus = createMemoryBus();
+    const repo = createMemoryRunsRepo();
+    registerRunRoutes(app, { bus, repo });
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/runs',
+      payload: { agentId: 'a', repo: 'o/r', base: 'main', prompt: 'p' },
+    });
+    const { id } = created.json() as { id: string };
+
+    // Status arrives before any logs - should set final state directly
+    await bus.publish(topics.runStatus(id), { state: 'done', detail: 'early completion' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('done');
+
+    // Publishing logs after terminal state should not change status
+    await bus.publish(topics.runLogs(id), 'log after done');
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('done'); // Should still be done, not running
+  });
+
+  it('idempotency: sending second terminal status should not change anything', async () => {
+    const app = Fastify();
+    const bus = createMemoryBus();
+    const repo = createMemoryRunsRepo();
+    registerRunRoutes(app, { bus, repo });
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/runs',
+      payload: { agentId: 'a', repo: 'o/r', base: 'main', prompt: 'p' },
+    });
+    const { id } = created.json() as { id: string };
+
+    // First terminal status
+    await bus.publish(topics.runStatus(id), { state: 'error', detail: 'first error' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('error');
+
+    // Second terminal status - should not change anything
+    await bus.publish(topics.runStatus(id), { state: 'done', detail: 'second status' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('error'); // Should still be error, not done
+
+    // Third terminal status - should not change anything
+    await bus.publish(topics.runStatus(id), { state: 'canceled', detail: 'third status' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('error'); // Should still be error, not canceled
+  });
+
+  it('watcher cleanup: after terminal status, publishing more logs/status should not mutate the run', async () => {
+    const app = Fastify();
+    const bus = createMemoryBus();
+    const repo = createMemoryRunsRepo();
+    registerRunRoutes(app, { bus, repo });
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/runs',
+      payload: { agentId: 'a', repo: 'o/r', base: 'main', prompt: 'p' },
+    });
+    const { id } = created.json() as { id: string };
+
+    // Set terminal state
+    await bus.publish(topics.runStatus(id), { state: 'canceled', detail: 'user canceled' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('canceled');
+
+    // Publish more logs - should not change status
+    await bus.publish(topics.runLogs(id), 'log after canceled');
+    await bus.publish(topics.runLogs(id), 'another log after canceled');
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('canceled'); // Should still be canceled, not running
+
+    // Publish more status messages - should not change status
+    await bus.publish(topics.runStatus(id), { state: 'done', detail: 'late done' });
+    await bus.publish(topics.runStatus(id), { state: 'error', detail: 'late error' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('canceled'); // Should still be canceled
+  });
 });

--- a/packages/api/test/runs.status.test.ts
+++ b/packages/api/test/runs.status.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import Fastify from 'fastify';
+import { registerRunRoutes } from '../src/runs/routes.js';
+import { createMemoryRunsRepo } from '../src/runs/repo.memory.js';
+import { createMemoryBus } from '../src/bus/memoryBus.js';
+import { topics } from '../src/bus/topics.js';
+
+describe('runs lifecycle via bus watchers', () => {
+  it('marks running on first log then done on status', async () => {
+    const app = Fastify();
+    const bus = createMemoryBus();
+    const repo = createMemoryRunsRepo();
+    registerRunRoutes(app, { bus, repo });
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/runs',
+      payload: { agentId: 'a', repo: 'o/r', base: 'main', prompt: 'p' },
+    });
+    const { id } = created.json() as { id: string };
+
+    // first log -> running
+    await bus.publish(topics.runLogs(id), 'hi');
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('running');
+
+    // status=done
+    await bus.publish(topics.runStatus(id), { state: 'done' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('done');
+  });
+
+  it('handles error and canceled terminals', async () => {
+    const app = Fastify();
+    const bus = createMemoryBus();
+    const repo = createMemoryRunsRepo();
+    registerRunRoutes(app, { bus, repo });
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/runs',
+      payload: { agentId: 'a', repo: 'o/r', base: 'main', prompt: 'p' },
+    });
+    const { id } = created.json() as { id: string };
+
+    await bus.publish(topics.runStatus(id), { state: 'error', detail: 'boom' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id)?.status).toBe('error');
+
+    const created2 = await app.inject({
+      method: 'POST',
+      url: '/runs',
+      payload: { agentId: 'a', repo: 'o/r', base: 'main', prompt: 'p2' },
+    });
+    const { id: id2 } = created2.json() as { id: string };
+    await bus.publish(topics.runStatus(id2), { state: 'canceled' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(repo.get(id2)?.status).toBe('canceled');
+  });
+});

--- a/packages/sdk-agent-node/test/sdk.status.memory.test.ts
+++ b/packages/sdk-agent-node/test/sdk.status.memory.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { AgentClient } from '../src/index.js';
+import { createMemoryTransport } from '../src/transports/memory.js';
+
+describe('AgentClient status helpers', () => {
+  it('publishes done/error/canceled', async () => {
+    const t = createMemoryTransport();
+    const agent = new AgentClient({ agentId: 'a1', transport: t });
+
+    const seen: Array<{ state: string; detail?: unknown }> = [];
+    const unsub = await t.subscribe<{ state: string; detail?: unknown }>('runs.r1.status', (m) =>
+      seen.push(m),
+    );
+
+    await agent.markDone('r1', { ok: true });
+    await agent.markError('r1', new Error('fail'));
+    await agent.markCanceled('r1', 'user');
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.map((s) => s.state)).toEqual(['done', 'error', 'canceled']);
+
+    await unsub();
+    await agent.close();
+  });
+});


### PR DESCRIPTION
Implements PR3.3 - Run lifecycle & status updates with automatic status transitions via bus messages.

## Changes
- Extended RunStatus to include running/done/error/canceled
- Automatic lifecycle management with per-run watchers
- Added runStatus topic helper
- SDK status helper methods (markDone/markError/markCanceled)
- Comprehensive tests for lifecycle transitions
- Updated README with lifecycle documentation

## Acceptance Criteria
- All tests pass (pnpm check green)
- Creating a run auto-attaches watchers
- Publishing a log makes run become running
- Status messages update run and clean watchers
- SDK helpers publish correct messages