### PR TITLE
feat(api): add local git plumbing (init, branch, commit, push to bare)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,30 @@ await applyPatch(
 );
 ```
 
+#### Local Git Plumbing (internal)
+
+Child-process wrappers around system `git` for local repository operations:
+
+```ts
+import {
+  initBareRemote,
+  initWorkspace,
+  ensureBranch,
+  stageAll,
+  commit,
+  push,
+} from '@prompt2prod/api/src/git/local';
+
+const remoteUrl = await initBareRemote('/tmp/remote.git');
+await initWorkspace('/tmp/work', remoteUrl);
+await ensureBranch('/tmp/work', 'feat/patch');
+await stageAll('/tmp/work');
+const sha = await commit('/tmp/work', 'feat: add changes', { name: 'bot', email: 'bot@local' });
+await push('/tmp/work', 'feat/patch');
+```
+
+Supports bare remote creation, workspace initialization, branch management, staging, committing, and pushing to local file-based remotes.
+
 ```
 
 ```

--- a/packages/api/src/git/local.ts
+++ b/packages/api/src/git/local.ts
@@ -1,0 +1,46 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs/promises';
+
+const ex = promisify(execFile);
+
+export type GitAuthor = { name: string; email: string };
+
+export async function initBareRemote(dir: string) {
+  await fs.mkdir(dir, { recursive: true });
+  await ex('git', ['init', '--bare'], { cwd: dir });
+  return `file://${dir}`;
+}
+
+export async function initWorkspace(dir: string, remoteUrl: string) {
+  await fs.mkdir(dir, { recursive: true });
+  await ex('git', ['init'], { cwd: dir });
+  await ex('git', ['remote', 'add', 'origin', remoteUrl], { cwd: dir });
+  await ex('git', ['config', 'user.name', 'prompt2prod'], { cwd: dir });
+  await ex('git', ['config', 'user.email', 'dev@local'], { cwd: dir });
+}
+
+export async function ensureBranch(dir: string, branch: string) {
+  await ex('git', ['checkout', '-B', branch], { cwd: dir });
+}
+
+export async function stageAll(dir: string) {
+  await ex('git', ['add', '-A'], { cwd: dir });
+}
+
+export async function commit(dir: string, message: string, author?: GitAuthor): Promise<string> {
+  const env = { ...process.env };
+  if (author) {
+    env.GIT_AUTHOR_NAME = author.name;
+    env.GIT_AUTHOR_EMAIL = author.email;
+    env.GIT_COMMITTER_NAME = author.name;
+    env.GIT_COMMITTER_EMAIL = author.email;
+  }
+  await ex('git', ['commit', '--no-gpg-sign', '--allow-empty', '-m', message], { cwd: dir, env });
+  const { stdout } = await ex('git', ['rev-parse', 'HEAD'], { cwd: dir });
+  return stdout.trim();
+}
+
+export async function push(dir: string, branch: string) {
+  await ex('git', ['push', 'origin', `HEAD:refs/heads/${branch}`], { cwd: dir });
+}

--- a/packages/api/test/git.local.test.ts
+++ b/packages/api/test/git.local.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { applyPatch } from '../src/patch/apply.js';
+import {
+  initBareRemote,
+  initWorkspace,
+  ensureBranch,
+  stageAll,
+  commit,
+  push,
+} from '../src/git/local.js';
+
+let tmp!: string;
+let bare!: string;
+let work!: string;
+const td = (p: string) => path.join(tmp, p);
+
+describe('local git plumbing', () => {
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), 'p2p-git-'));
+    bare = td('remote.git');
+    work = td('work');
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('creates a branch and pushes a commit to a bare remote', async () => {
+    const remoteUrl = await initBareRemote(bare);
+    await initWorkspace(work, remoteUrl);
+
+    await applyPatch(
+      {
+        files: [
+          { path: 'README.generated.md', content: '# Hello\n' },
+          { path: 'src/index.ts', content: 'export const x=1;\n' },
+        ],
+      },
+      { rootDir: work, normalizeEol: 'lf' },
+    );
+
+    await ensureBranch(work, 'feat/patch');
+    await stageAll(work);
+    const sha = await commit(work, 'chore: seed workspace', { name: 'bot', email: 'bot@local' });
+    await push(work, 'feat/patch');
+
+    const ref = execFileSync(
+      'git',
+      ['for-each-ref', '--format=%(objectname)', 'refs/heads/feat/patch'],
+      { cwd: bare },
+    )
+      .toString()
+      .trim();
+    expect(ref).toBe(sha);
+  });
+});


### PR DESCRIPTION
## PR4.1b — Local Git plumbing (no GitHub yet)

### Role
You are **Backend**. Implement **local Git plumbing** to turn applied patches into a commit on a branch and push to a **bare** remote (). No GitHub API calls in this PR.

### Scope
* Child-process wrappers around system usage: git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           [--super-prefix=<path>] [--config-env=<name>=<envvar>]
           <command> [<args>]

These are common Git commands used in various situations:

start a working area (see also: git help tutorial)
   clone     Clone a repository into a new directory
   init      Create an empty Git repository or reinitialize an existing one

work on the current change (see also: git help everyday)
   add       Add file contents to the index
   mv        Move or rename a file, a directory, or a symlink
   restore   Restore working tree files
   rm        Remove files from the working tree and from the index

examine the history and state (see also: git help revisions)
   bisect    Use binary search to find the commit that introduced a bug
   diff      Show changes between commits, commit and working tree, etc
   grep      Print lines matching a pattern
   log       Show commit logs
   show      Show various types of objects
   status    Show the working tree status

grow, mark and tweak your common history
   branch    List, create, or delete branches
   commit    Record changes to the repository
   merge     Join two or more development histories together
   rebase    Reapply commits on top of another base tip
   reset     Reset current HEAD to the specified state
   switch    Switch branches
   tag       Create, list, delete or verify a tag object signed with GPG

collaborate (see also: git help workflows)
   fetch     Download objects and refs from another repository
   pull      Fetch from and integrate with another repository or a local branch
   push      Update remote refs along with associated objects

'git help -a' and 'git help -g' list available subcommands and some
concept guides. See 'git help <command>' or 'git help <concept>'
to read about a specific subcommand or concept.
See 'git help git' for an overview of the system..
* Helpers: init **bare** remote, init workspace, ensure branch, stage, commit, push.
* Tests with a tmp **bare** repo + tmp workspace.
* Small internal README note.

### Files Added
*  - Main implementation with all Git helper functions
*  - Comprehensive test for the complete workflow
*  - Added documentation section with usage examples

### Key Features
* **Child-process wrappers** around system usage: git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           [--super-prefix=<path>] [--config-env=<name>=<envvar>]
           <command> [<args>]

These are common Git commands used in various situations:

start a working area (see also: git help tutorial)
   clone     Clone a repository into a new directory
   init      Create an empty Git repository or reinitialize an existing one

work on the current change (see also: git help everyday)
   add       Add file contents to the index
   mv        Move or rename a file, a directory, or a symlink
   restore   Restore working tree files
   rm        Remove files from the working tree and from the index

examine the history and state (see also: git help revisions)
   bisect    Use binary search to find the commit that introduced a bug
   diff      Show changes between commits, commit and working tree, etc
   grep      Print lines matching a pattern
   log       Show commit logs
   show      Show various types of objects
   status    Show the working tree status

grow, mark and tweak your common history
   branch    List, create, or delete branches
   commit    Record changes to the repository
   merge     Join two or more development histories together
   rebase    Reapply commits on top of another base tip
   reset     Reset current HEAD to the specified state
   switch    Switch branches
   tag       Create, list, delete or verify a tag object signed with GPG

collaborate (see also: git help workflows)
   fetch     Download objects and refs from another repository
   pull      Fetch from and integrate with another repository or a local branch
   push      Update remote refs along with associated objects

'git help -a' and 'git help -g' list available subcommands and some
concept guides. See 'git help <command>' or 'git help <concept>'
to read about a specific subcommand or concept.
See 'git help git' for an overview of the system. commands using 
* **Bare remote creation** with  URLs for local testing
* **Workspace initialization** with proper Git configuration
* **Branch management** with  for create-or-switch
* **Staging and committing** with author override support
* **Pushing** to local file-based remotes
* **No network usage** - purely local Git operations

### Testing
* **Test passes** and verifies the complete workflow
* **No network dependencies** - uses temporary directories and local Git
* **Integration** with existing  functionality
* **Proper cleanup** with temporary directory removal

### Acceptance Criteria ✅
* 
> prompt2prod@ check /Users/xilosada/dev/ai2prod
> pnpm lint && pnpm format:check && pnpm typecheck && pnpm test && pnpm build


> prompt2prod@ lint /Users/xilosada/dev/ai2prod
> eslint . --ext .ts


> prompt2prod@ format:check /Users/xilosada/dev/ai2prod
> prettier -c .

Checking formatting...
All matched files use Prettier code style!

> prompt2prod@ typecheck /Users/xilosada/dev/ai2prod
> pnpm -r typecheck

Scope: 3 of 4 workspace projects
packages/api typecheck$ tsc -p tsconfig.json --noEmit
packages/sdk-agent-node typecheck$ tsc -p tsconfig.json --noEmit
packages/shared typecheck$ tsc -p tsconfig.json --noEmit
packages/shared typecheck: Done
packages/sdk-agent-node typecheck: Done
packages/api typecheck: Done

> prompt2prod@ test /Users/xilosada/dev/ai2prod
> pnpm -r test

Scope: 3 of 4 workspace projects
packages/api test$ vitest run
packages/sdk-agent-node test$ vitest run
packages/shared test$ vitest run
packages/api test:  RUN  v2.1.9 /Users/xilosada/dev/ai2prod/packages/api
packages/sdk-agent-node test:  RUN  v2.1.9 /Users/xilosada/dev/ai2prod/packages/sdk-agent-node
packages/shared test:  RUN  v2.1.9 /Users/xilosada/dev/ai2prod/packages/shared
packages/sdk-agent-node test:  ✓ test/sdk.memory.test.ts (1 test) 11ms
packages/sdk-agent-node test:  ✓ test/sdk.status.memory.test.ts (1 test) 12ms
packages/shared test:  ✓ test/types.test.ts (1 test) 1ms
packages/sdk-agent-node test:  Test Files  2 passed (2)
packages/sdk-agent-node test:       Tests  2 passed (2)
packages/sdk-agent-node test:    Start at  00:36:34
packages/sdk-agent-node test:    Duration  371ms (transform 39ms, setup 0ms, collect 74ms, tests 23ms, environment 0ms, prepare 110ms)
packages/shared test:  Test Files  1 passed (1)
packages/shared test:       Tests  1 passed (1)
packages/shared test:    Start at  00:36:34
packages/shared test:    Duration  376ms (transform 21ms, setup 0ms, collect 18ms, tests 1ms, environment 0ms, prepare 62ms)
packages/sdk-agent-node test: Done
packages/shared test: Done
packages/api test:  ✓ test/bus.factory.test.ts (3 tests | 1 skipped) 2ms
packages/api test:  ↓ test/bus.nats.test.ts (3 tests | 3 skipped)
packages/api test:  ✓ test/bus.memory.test.ts (7 tests) 36ms
packages/api test:  ✓ test/patch.apply.test.ts (14 tests) 119ms
packages/api test:  ✓ test/health.test.ts (1 test) 30ms
packages/api test:  ✓ test/runs.routes.test.ts (3 tests) 60ms
packages/api test:  ✓ test/git.local.test.ts (1 test) 244ms
packages/api test:  ✓ test/runs.status.test.ts (5 tests) 193ms
packages/api test:  ✓ test/e2e.runs.sse.test.ts (1 test) 4051ms
packages/api test:    ✓ E2E: run dispatch + SSE logs > POST /runs publishes work; SSE receives a log 4050ms
packages/api test:  Test Files  8 passed | 1 skipped (9)
packages/api test:       Tests  34 passed | 4 skipped (38)
packages/api test:    Start at  00:36:34
packages/api test:    Duration  4.54s (transform 210ms, setup 0ms, collect 662ms, tests 4.73s, environment 1ms, prepare 416ms)
packages/api test: Done

> prompt2prod@ build /Users/xilosada/dev/ai2prod
> pnpm -r build

Scope: 3 of 4 workspace projects
packages/api build$ tsc -p tsconfig.json
packages/sdk-agent-node build$ tsc -p tsconfig.json
packages/shared build$ tsc -p tsconfig.json
packages/shared build: Done
packages/sdk-agent-node build: Done
packages/api build: Done green ✅
* Test pushes a branch to a bare repo and the ref matches the commit SHA ✅
* No GitHub/network usage; purely local Git ✅