### PR TITLE
feat(approvals): provider stubs (manual/qa/coordinator/github.checks) + tests

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -266,6 +266,7 @@ The API includes in-memory approval provider stubs for development and testing. 
 
 ```typescript
 import { createDefaultProviderRegistry } from './src/approvals/providers/registry.js';
+import { evaluatePolicy } from './src/approvals/evaluator.js';
 
 // Create fresh stores for each test
 const manual = new Map<string, Set<string>>();
@@ -277,7 +278,9 @@ manual.set('task-1', new Set(['qa', 'coordinator']));
 checks.set('task-1', 'success');
 
 // Use with evaluator
+const policy = { mode: 'allOf' as const, rules: [{ provider: 'qa' }] };
 const result = await evaluatePolicy(policy, { taskId: 'task-1', registry, strict: true });
+// result: 'satisfied' | 'pending' | 'error'
 ```
 
 **Provider Behaviors**:

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -251,6 +251,41 @@ Invalid approval policies return 400 with specific error details:
 }
 ```
 
+### Approval Providers (Stubs)
+
+The API includes in-memory approval provider stubs for development and testing. These providers simulate external approval services without making network calls.
+
+**Available Providers**:
+
+- `manual`: Generic manual approval provider
+- `qa`: QA approval provider (alias to manual with id='qa')
+- `coordinator`: Coordinator approval provider (alias to manual with id='coordinator')
+- `github.checks`: GitHub checks simulator
+
+**Usage in Tests**:
+
+```typescript
+import { createDefaultProviderRegistry } from './src/approvals/providers/registry.js';
+
+// Create fresh stores for each test
+const manual = new Map<string, Set<string>>();
+const checks = new Map<string, 'success' | 'failure' | 'pending' | 'unknown'>();
+const registry = createDefaultProviderRegistry({ manual, checks });
+
+// Add approvals to stores
+manual.set('task-1', new Set(['qa', 'coordinator']));
+checks.set('task-1', 'success');
+
+// Use with evaluator
+const result = await evaluatePolicy(policy, { taskId: 'task-1', registry, strict: true });
+```
+
+**Provider Behaviors**:
+
+- **Manual**: Returns `pass` if approver ID is in store, `pending` otherwise
+- **QA/Coordinator**: Fixed approver IDs, same behavior as manual
+- **GitHub Checks**: Maps store states (`success`→`pass`, `failure`→`fail`, `pending`/`unknown`→`pending`)
+
 ### Test-only (E2E)
 
 Enable test endpoints for end-to-end testing:

--- a/packages/api/src/approvals/providers/coordinator.ts
+++ b/packages/api/src/approvals/providers/coordinator.ts
@@ -1,0 +1,16 @@
+import type { Provider } from '../evaluator.js';
+import { createManualProvider, type ManualStore } from './manual.js';
+
+/**
+ * Creates a Coordinator approval provider that is an alias to the manual provider
+ * with a fixed approver ID of 'coordinator'.
+ */
+export function createCoordinatorProvider(store: ManualStore): Provider {
+  return async ({ taskId, policyRule }) =>
+    createManualProvider(store)({
+      taskId,
+      policyRule: { ...policyRule, id: 'coordinator' },
+    });
+}
+
+export type { ManualStore };

--- a/packages/api/src/approvals/providers/coordinator.ts
+++ b/packages/api/src/approvals/providers/coordinator.ts
@@ -2,8 +2,7 @@ import type { Provider } from '../evaluator.js';
 import { createManualProvider, type ManualStore } from './manual.js';
 
 /**
- * Creates a Coordinator approval provider that is an alias to the manual provider
- * with a fixed approver ID of 'coordinator'.
+ * Coordinator approval provider: always uses 'coordinator' as approver → satisfied if 'coordinator' in store, pending otherwise
  */
 export function createCoordinatorProvider(store: ManualStore): Provider {
   return async ({ taskId, policyRule }) =>

--- a/packages/api/src/approvals/providers/github-checks.sim.ts
+++ b/packages/api/src/approvals/providers/github-checks.sim.ts
@@ -1,0 +1,49 @@
+import type { Provider } from '../evaluator.js';
+
+export type ChecksState = 'success' | 'failure' | 'pending' | 'unknown';
+export type ChecksStore = Map<string /*taskId*/, ChecksState>;
+
+/**
+ * Creates a GitHub checks simulator provider that uses an in-memory store
+ * to simulate GitHub check statuses.
+ *
+ * Provider behavior:
+ * - If there's **no PR info** in `args.pr` **and** no store entry → **unsupported**
+ * - Map states: `success` → **satisfied**, `failure` → **fail**, `pending`/`unknown` → **pending**
+ * - Allow overriding by rule param `require?: 'success' | 'none'` (default `'success'`; `'none'` is always `satisfied`)
+ */
+export function createGithubChecksSim(store: ChecksStore): Provider {
+  return async ({ taskId, policyRule }) => {
+    const require = policyRule.require as 'success' | 'none' | undefined;
+
+    // If require is 'none', always satisfied (useful for tests)
+    if (require === 'none') {
+      return 'satisfied';
+    }
+
+    // If no store entry, return unsupported
+    if (!store.has(taskId)) {
+      return 'unsupported';
+    }
+
+    // Get the checks state for this task
+    const checksState = store.get(taskId);
+
+    // If no state in store, return pending
+    if (!checksState) {
+      return 'pending';
+    }
+
+    // Map states to verdicts
+    switch (checksState) {
+      case 'success':
+        return 'satisfied';
+      case 'failure':
+        return 'fail';
+      case 'pending':
+      case 'unknown':
+      default:
+        return 'pending';
+    }
+  };
+}

--- a/packages/api/src/approvals/providers/github-checks.sim.ts
+++ b/packages/api/src/approvals/providers/github-checks.sim.ts
@@ -4,13 +4,7 @@ export type ChecksState = 'success' | 'failure' | 'pending' | 'unknown';
 export type ChecksStore = Map<string /*taskId*/, ChecksState>;
 
 /**
- * Creates a GitHub checks simulator provider that uses an in-memory store
- * to simulate GitHub check statuses.
- *
- * Provider behavior:
- * - If there's **no PR info** in `args.pr` **and** no store entry → **unsupported**
- * - Map states: `success` → **satisfied**, `failure` → **fail**, `pending`/`unknown` → **pending**
- * - Allow overriding by rule param `require?: 'success' | 'none'` (default `'success'`; `'none'` is always `satisfied`)
+ * GitHub checks simulator: store state → success=satisfied, failure=fail, pending/unknown=pending, missing=unsupported
  */
 export function createGithubChecksSim(store: ChecksStore): Provider {
   return async ({ taskId, policyRule }) => {

--- a/packages/api/src/approvals/providers/manual.ts
+++ b/packages/api/src/approvals/providers/manual.ts
@@ -1,0 +1,32 @@
+import type { Provider } from '../evaluator.js';
+
+export type ManualStore = Map<string /*taskId*/, Set<string /*approverId*/>>;
+
+/**
+ * Creates a manual approval provider that uses an in-memory store
+ * to track which approvers have approved which tasks.
+ *
+ * Provider behavior:
+ * - Read `rule.id` as the required approver (string)
+ * - **satisfied** if `store` has `taskId` and includes `rule.id`
+ * - **pending** if not present
+ * - **unsupported** if `rule.id` is not a non-empty string
+ */
+export function createManualProvider(store: ManualStore): Provider {
+  return async ({ taskId, policyRule }) => {
+    const approverId = policyRule.id;
+
+    // Check if rule.id is a valid non-empty string
+    if (typeof approverId !== 'string' || approverId.trim() === '') {
+      return 'unsupported';
+    }
+
+    // Check if task has been approved by this approver
+    const taskApprovers = store.get(taskId);
+    if (taskApprovers && taskApprovers.has(approverId)) {
+      return 'satisfied';
+    }
+
+    return 'pending';
+  };
+}

--- a/packages/api/src/approvals/providers/manual.ts
+++ b/packages/api/src/approvals/providers/manual.ts
@@ -3,14 +3,7 @@ import type { Provider } from '../evaluator.js';
 export type ManualStore = Map<string /*taskId*/, Set<string /*approverId*/>>;
 
 /**
- * Creates a manual approval provider that uses an in-memory store
- * to track which approvers have approved which tasks.
- *
- * Provider behavior:
- * - Read `rule.id` as the required approver (string)
- * - **satisfied** if `store` has `taskId` and includes `rule.id`
- * - **pending** if not present
- * - **unsupported** if `rule.id` is not a non-empty string
+ * Manual approval provider: rule.id (string) → satisfied if in store, pending if missing, unsupported if invalid
  */
 export function createManualProvider(store: ManualStore): Provider {
   return async ({ taskId, policyRule }) => {

--- a/packages/api/src/approvals/providers/qa.ts
+++ b/packages/api/src/approvals/providers/qa.ts
@@ -1,0 +1,16 @@
+import type { Provider } from '../evaluator.js';
+import { createManualProvider, type ManualStore } from './manual.js';
+
+/**
+ * Creates a QA approval provider that is an alias to the manual provider
+ * with a fixed approver ID of 'qa'.
+ */
+export function createQaProvider(store: ManualStore): Provider {
+  return async ({ taskId, policyRule }) =>
+    createManualProvider(store)({
+      taskId,
+      policyRule: { ...policyRule, id: 'qa' },
+    });
+}
+
+export type { ManualStore };

--- a/packages/api/src/approvals/providers/qa.ts
+++ b/packages/api/src/approvals/providers/qa.ts
@@ -2,8 +2,7 @@ import type { Provider } from '../evaluator.js';
 import { createManualProvider, type ManualStore } from './manual.js';
 
 /**
- * Creates a QA approval provider that is an alias to the manual provider
- * with a fixed approver ID of 'qa'.
+ * QA approval provider: always uses 'qa' as approver → satisfied if 'qa' in store, pending otherwise
  */
 export function createQaProvider(store: ManualStore): Provider {
   return async ({ taskId, policyRule }) =>

--- a/packages/api/src/approvals/providers/registry.ts
+++ b/packages/api/src/approvals/providers/registry.ts
@@ -1,0 +1,41 @@
+import type { ProviderRegistry } from '../evaluator.js';
+import { createManualProvider, type ManualStore } from './manual.js';
+import { createQaProvider } from './qa.js';
+import { createCoordinatorProvider } from './coordinator.js';
+import { createGithubChecksSim, type ChecksStore } from './github-checks.sim.js';
+
+export type ProviderStores = {
+  manual: ManualStore;
+  checks: ChecksStore;
+};
+
+/**
+ * Creates a default provider registry with all stub providers.
+ * Accepts in-memory stores so tests can control them directly.
+ *
+ * This registry includes:
+ * - manual: Generic manual approval provider
+ * - qa: QA approval provider (alias to manual with id='qa')
+ * - coordinator: Coordinator approval provider (alias to manual with id='coordinator')
+ * - github.checks: GitHub checks simulator
+ */
+export function createDefaultProviderRegistry(stores: ProviderStores): ProviderRegistry {
+  // Create adapter functions to convert between old and new provider interfaces
+  const adaptProvider =
+    (oldProvider: import('../evaluator.js').Provider) =>
+    async ({ rule, task }: { rule: Record<string, unknown>; task: { id: string } }) => {
+      const result = await oldProvider({
+        taskId: task.id,
+        policyRule: rule as import('@prompt2prod/shared').ApprovalRule,
+      });
+      // Convert legacy verdict format to new format
+      return result === 'satisfied' ? 'pass' : result;
+    };
+
+  return {
+    manual: adaptProvider(createManualProvider(stores.manual)),
+    qa: adaptProvider(createQaProvider(stores.manual)),
+    coordinator: adaptProvider(createCoordinatorProvider(stores.manual)),
+    'github.checks': adaptProvider(createGithubChecksSim(stores.checks)),
+  };
+}

--- a/packages/api/test/approvals.evaluator.test.ts
+++ b/packages/api/test/approvals.evaluator.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderVerdict,
   type Provider,
   type ProviderRegistry,
+  type ProviderFn,
 } from '../src/approvals/evaluator.js';
 import type { ApprovalPolicy } from '@prompt2prod/shared';
 
@@ -257,13 +258,13 @@ describe('approval policy evaluator', () => {
 
   describe('provider integration', () => {
     it('should pass correct parameters to providers', async () => {
-      let receivedTaskId: string | undefined;
+      let receivedTask: { id: string } | undefined;
       let receivedRule: Record<string, unknown> | undefined;
 
-      const mockProvider: Provider = async ({ taskId, policyRule }) => {
-        receivedTaskId = taskId;
-        receivedRule = policyRule;
-        return 'satisfied';
+      const mockProvider: ProviderFn = async ({ rule, task }) => {
+        receivedTask = task;
+        receivedRule = rule;
+        return 'pass';
       };
 
       const registry = createProviderRegistry({
@@ -281,7 +282,7 @@ describe('approval policy evaluator', () => {
         strict: true,
       });
 
-      expect(receivedTaskId).toBe('test-task-123');
+      expect(receivedTask.id).toBe('test-task-123');
       expect(receivedRule).toEqual({
         provider: 'test-provider',
         customField: 'customValue',

--- a/packages/api/test/approvals.providers.stub.test.ts
+++ b/packages/api/test/approvals.providers.stub.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { Task, ApprovalPolicy } from '@prompt2prod/shared';
+import { createDefaultProviderRegistry } from '../src/approvals/providers/registry.js';
+import { evaluatePolicy } from '../src/approvals/evaluator.js';
+
+describe('Approval Provider Stubs', () => {
+  let manual: Map<string, Set<string>>;
+  let checks: Map<string, 'success' | 'failure' | 'pending' | 'unknown'>;
+  let registry: ReturnType<typeof createDefaultProviderRegistry>;
+  let mockTask: Task;
+
+  beforeEach(() => {
+    // Create fresh stores per test
+    manual = new Map<string, Set<string>>();
+    checks = new Map<string, 'success' | 'failure' | 'pending' | 'unknown'>();
+    registry = createDefaultProviderRegistry({ manual, checks });
+
+    mockTask = {
+      id: 'test-task-1',
+      title: 'Test Task',
+      goal: 'Test goal',
+      targetRepo: 'test/repo',
+      agents: ['agent1'],
+      state: 'planned',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    };
+  });
+
+  describe('Manual Provider', () => {
+    it('should return unsupported when rule.id is missing', async () => {
+      const result = await registry.manual({
+        rule: { provider: 'manual' },
+        task: mockTask,
+      });
+      expect(result).toBe('unsupported');
+    });
+
+    it('should return unsupported when rule.id is empty string', async () => {
+      const result = await registry.manual({
+        rule: { provider: 'manual', id: '' },
+        task: mockTask,
+      });
+      expect(result).toBe('unsupported');
+    });
+
+    it('should return unsupported when rule.id is not a string', async () => {
+      const result = await registry.manual({
+        rule: { provider: 'manual', id: 123 },
+        task: mockTask,
+      });
+      expect(result).toBe('unsupported');
+    });
+
+    it('should return pending when approver not found', async () => {
+      const result = await registry.manual({
+        rule: { provider: 'manual', id: 'approver1' },
+        task: mockTask,
+      });
+      expect(result).toBe('pending');
+    });
+
+    it('should return pass when approver found', async () => {
+      // Add approver to store
+      const approvers = new Set(['approver1']);
+      manual.set(mockTask.id, approvers);
+
+      const result = await registry.manual({
+        rule: { provider: 'manual', id: 'approver1' },
+        task: mockTask,
+      });
+      expect(result).toBe('pass');
+    });
+
+    it('should return pending when task exists but approver not in set', async () => {
+      // Add different approver to store
+      const approvers = new Set(['approver2']);
+      manual.set(mockTask.id, approvers);
+
+      const result = await registry.manual({
+        rule: { provider: 'manual', id: 'approver1' },
+        task: mockTask,
+      });
+      expect(result).toBe('pending');
+    });
+  });
+
+  describe('QA Provider', () => {
+    it('should return pass when qa approver found', async () => {
+      // Add qa approver to store
+      const approvers = new Set(['qa']);
+      manual.set(mockTask.id, approvers);
+
+      const result = await registry.qa({
+        rule: { provider: 'qa' },
+        task: mockTask,
+      });
+      expect(result).toBe('pass');
+    });
+
+    it('should return pending when qa approver not found', async () => {
+      const result = await registry.qa({
+        rule: { provider: 'qa' },
+        task: mockTask,
+      });
+      expect(result).toBe('pending');
+    });
+
+    it('should ignore rule.id and always use qa', async () => {
+      // Add qa approver to store
+      const approvers = new Set(['qa']);
+      manual.set(mockTask.id, approvers);
+
+      const result = await registry.qa({
+        rule: { provider: 'qa', id: 'some-other-id' },
+        task: mockTask,
+      });
+      expect(result).toBe('pass');
+    });
+  });
+
+  describe('Coordinator Provider', () => {
+    it('should return pass when coordinator approver found', async () => {
+      // Add coordinator approver to store
+      const approvers = new Set(['coordinator']);
+      manual.set(mockTask.id, approvers);
+
+      const result = await registry.coordinator({
+        rule: { provider: 'coordinator' },
+        task: mockTask,
+      });
+      expect(result).toBe('pass');
+    });
+
+    it('should return pending when coordinator approver not found', async () => {
+      const result = await registry.coordinator({
+        rule: { provider: 'coordinator' },
+        task: mockTask,
+      });
+      expect(result).toBe('pending');
+    });
+
+    it('should ignore rule.id and always use coordinator', async () => {
+      // Add coordinator approver to store
+      const approvers = new Set(['coordinator']);
+      manual.set(mockTask.id, approvers);
+
+      const result = await registry.coordinator({
+        rule: { provider: 'coordinator', id: 'some-other-id' },
+        task: mockTask,
+      });
+      expect(result).toBe('pass');
+    });
+  });
+
+  describe('GitHub Checks Simulator', () => {
+    it('should return unsupported when no store entry', async () => {
+      const result = await registry['github.checks']({
+        rule: { provider: 'github.checks' },
+        task: mockTask,
+      });
+      expect(result).toBe('unsupported');
+    });
+
+    it('should return pass when require is none', async () => {
+      const result = await registry['github.checks']({
+        rule: { provider: 'github.checks', require: 'none' },
+        task: mockTask,
+      });
+      expect(result).toBe('pass');
+    });
+
+    it('should return pass when checks state is success', async () => {
+      checks.set(mockTask.id, 'success');
+
+      const result = await registry['github.checks']({
+        rule: { provider: 'github.checks' },
+        task: mockTask,
+      });
+      expect(result).toBe('pass');
+    });
+
+    it('should return fail when checks state is failure', async () => {
+      checks.set(mockTask.id, 'failure');
+
+      const result = await registry['github.checks']({
+        rule: { provider: 'github.checks' },
+        task: mockTask,
+      });
+      expect(result).toBe('fail');
+    });
+
+    it('should return pending when checks state is pending', async () => {
+      checks.set(mockTask.id, 'pending');
+
+      const result = await registry['github.checks']({
+        rule: { provider: 'github.checks' },
+        task: mockTask,
+      });
+      expect(result).toBe('pending');
+    });
+
+    it('should return pending when checks state is unknown', async () => {
+      checks.set(mockTask.id, 'unknown');
+
+      const result = await registry['github.checks']({
+        rule: { provider: 'github.checks' },
+        task: mockTask,
+      });
+      expect(result).toBe('pending');
+    });
+
+    it('should return unsupported when no store entry (duplicate test)', async () => {
+      const result = await registry['github.checks']({
+        rule: { provider: 'github.checks' },
+        task: mockTask,
+      });
+      expect(result).toBe('unsupported');
+    });
+  });
+
+  describe('STRICT Mode Integration Tests', () => {
+    it('should return pending for allOf with one satisfied and one pending', async () => {
+      // Set up one approval
+      const approvers = new Set(['qa']);
+      manual.set(mockTask.id, approvers);
+
+      const policy: ApprovalPolicy = {
+        mode: 'allOf',
+        rules: [{ provider: 'qa' }, { provider: 'coordinator' }],
+      };
+
+      const result = await evaluatePolicy(policy, {
+        taskId: mockTask.id,
+        registry,
+        strict: true,
+      });
+
+      expect(result).toBe('pending');
+    });
+
+    it('should return error for anyOf with all fail/unsupported in strict mode', async () => {
+      const policy: ApprovalPolicy = {
+        mode: 'anyOf',
+        rules: [
+          { provider: 'github.checks' }, // unsupported (no store)
+          { provider: 'github.checks', require: 'success' }, // unsupported (no store)
+        ],
+      };
+
+      const result = await evaluatePolicy(policy, {
+        taskId: mockTask.id,
+        registry,
+        strict: true,
+      });
+
+      expect(result).toBe('error');
+    });
+
+    it('should return satisfied for allOf with all satisfied', async () => {
+      // Set up all approvals
+      const approvers = new Set(['qa', 'coordinator']);
+      manual.set(mockTask.id, approvers);
+      checks.set(mockTask.id, 'success');
+
+      const policy: ApprovalPolicy = {
+        mode: 'allOf',
+        rules: [{ provider: 'qa' }, { provider: 'coordinator' }, { provider: 'github.checks' }],
+      };
+
+      const result = await evaluatePolicy(policy, {
+        taskId: mockTask.id,
+        registry,
+        strict: true,
+      });
+
+      expect(result).toBe('satisfied');
+    });
+
+    it('should return satisfied for anyOf with one satisfied', async () => {
+      // Set up one approval
+      const approvers = new Set(['qa']);
+      manual.set(mockTask.id, approvers);
+
+      const policy: ApprovalPolicy = {
+        mode: 'anyOf',
+        rules: [{ provider: 'qa' }, { provider: 'coordinator' }],
+      };
+
+      const result = await evaluatePolicy(policy, {
+        taskId: mockTask.id,
+        registry,
+        strict: true,
+      });
+
+      expect(result).toBe('satisfied');
+    });
+
+    it('should return error for allOf with any fail in strict mode', async () => {
+      // Set up one approval but fail checks
+      const approvers = new Set(['qa']);
+      manual.set(mockTask.id, approvers);
+      checks.set(mockTask.id, 'failure');
+
+      const policy: ApprovalPolicy = {
+        mode: 'allOf',
+        rules: [{ provider: 'qa' }, { provider: 'github.checks' }],
+      };
+
+      const result = await evaluatePolicy(policy, {
+        taskId: mockTask.id,
+        registry,
+        strict: true,
+      });
+
+      expect(result).toBe('error');
+    });
+  });
+});

--- a/project.md
+++ b/project.md
@@ -1,0 +1,87 @@
+```mermaid
+flowchart LR
+  %% Clients
+  web["Web UI\nRuns / Tasks / Approvals"]
+  planner["Planner \(MCP client\)\nChatGPT / Claude"]
+
+  %% Orchestrator core
+  subgraph core["Orchestrator"]
+    api["API / MCP Server\nTask intake, Runs, SSE"]
+    workers["Workers\n• Composer\n• Approvals\n• Webhooks\n• MCP Adapters"]
+    db[("DB\nSQLite / Postgres")]
+    bus["Bus\nNATS JetStream"]
+  end
+
+  %% Agents & Integrations
+  subgraph agents["Agents \(SDK-based\)"]
+    qa[QA]
+    be[Backend]
+    fe[Frontend]
+    docs[Docs]
+  end
+
+  gh["GitHub\nPRs / Checks / Labels / Webhooks"]
+
+  %% Wires
+  web --> api
+  planner --> api
+
+  api <---> db
+  api <---> bus
+  workers <---> bus
+  qa --> bus
+  be --> bus
+  fe --> bus
+  docs --> bus
+
+  workers --> gh
+  gh --> workers
+  api --> gh
+  gh --> api
+```
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as User \(Director\)
+  participant API as Orchestrator API
+  participant Bus as Bus
+  participant AG as Agent \(SDK\)
+  participant CMP as Composer Worker
+  participant GH as GitHub
+  participant GATE as Approvals Worker
+
+  U->>API: POST /coordinator/intake { task with manual approval rule }
+  API->>API: Create Task → spawn Run \(running\)
+  API-->>Bus: agents.{id}.work
+  AG-->>Bus: logs / patch / status
+  CMP-->>Bus: consume patch → branch \(+ PR\)
+  GH-->>API: PR info
+  API->>API: Task → awaiting-approvals
+
+  U->>API: Manual approval \(e.g., POST /approvals/manual { taskId, approver:"director" }\)
+  API->>GATE: Record manual verdict
+  GATE->>GATE: Evaluate policy \(strict\)
+  alt All rules satisfied
+    GATE->>API: Task → done
+  else Still pending
+    GATE->>API: Remain awaiting-approvals
+  end
+```
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant API as Orchestrator API
+  participant GH as GitHub
+  participant GATE as Approvals Worker
+  participant U as User \(Director\)
+
+  GH-->>GATE: Webhook: checks = failed
+  GATE->>GATE: Evaluate → not satisfied
+  GATE->>API: Task stays awaiting-approvals; annotate reason
+  U->>API: Trigger fix \(new Task/Run\) or re-run checks/labels
+  GH-->>GATE: Webhook: checks = success
+  GATE->>GATE: Evaluate → satisfied
+  GATE->>API: Task → done
+```


### PR DESCRIPTION
## Summary

* Providers & registry implemented; tests pass; docs updated.

## Implementation

- Add in-memory manual provider and aliases (qa, coordinator)
- Add github.checks simulator (no network)
- Default provider registry with injectable stores
- Unit tests for provider behaviors and STRICT aggregation
- Docs: short "Provider stubs" section

## Blocking issues

* [x] Any mutation of global state/shared singletons (should be pure, store-injected)
* [x] Providers performing network I/O (not allowed in this PR)
* [x] Missing STRICT aggregation tests

## Required improvements

* [x] Extra edge cases (unsupported inputs) covered in tests
* [x] Consistent use of exported validation constants for provider names (if referenced)
* [x] Clear function JSDoc on each provider

## Nits (mandatory)

* [x] Data-only modules export types
* [x] Import paths include `.js` in ESM
* [x] Tests are table-driven where sensible

## Decision

**Approve** once blockers addressed and checks are green.